### PR TITLE
Restoring grammar back to include human-readable operators

### DIFF
--- a/src/main/antlr4/com/gmathur/resql/ResqlLang.g4
+++ b/src/main/antlr4/com/gmathur/resql/ResqlLang.g4
@@ -30,7 +30,7 @@ between     : FIELD BTW tuple;
 in          : FIELD IN (arrayN | arrayS);
 // An array or a range of numbers
 arrayN      : SQOPEN NUMBER (SEP | NUMBER)* SQCLOSE;
-arrayS      : SQOPEN  (SEP | STRING)* SQCLOSE;
+arrayS      : SQOPEN (SEP | STRING)* SQCLOSE;
 // The regex string is not lexed as a valid regex string adhering to a standard, but instead as a STRING. A valid regex
 // string will have to be checked by the respected adapters
 like        : FIELD (MATCH | NEGMATCH) STRING;
@@ -42,6 +42,8 @@ tuple       : OPENPAREN NUMBER SEP NUMBER CLOSEPAREN;
 
 // Non-tokens
 fragment A :('A'|'a');
+fragment B :('B'|'b');
+fragment C :('C'|'c');
 fragment D :('D'|'d');
 fragment E :('E'|'e');
 fragment G :('G'|'g');
@@ -53,6 +55,7 @@ fragment O :('O'|'o');
 fragment Q :('Q'|'q');
 fragment R :('R'|'r');
 fragment T :('T'|'t');
+fragment W :('W'|'w');
 
 fragment DIGIT          : [0-9];
 fragment UPPERCASE      : [A-Z];
@@ -66,8 +69,6 @@ fragment PERCENT     : '%';
 fragment PERIOD      : '.';
 fragment STAR        : '*';
 fragment QUESTION    : '?';
-fragment OPENBRACE   : '{';
-fragment CLOSEBRACE  : '}';
 fragment DOLLAR      : '$';
 fragment PLUS        : '+';
 
@@ -77,21 +78,23 @@ SQOPEN      : '[';
 SQCLOSE     : ']';
 OPENPAREN   : '(';
 CLOSEPAREN  : ')';
+CLOSEBRACE  : '}';
+OPENBRACE   : '{';
 
 // Comparison operators - comparing values yielding a true or false result
-EQ          : E Q; // equal to
-NEQ         : '!='; // not equal to
-GTE         : '>='; // greater than or equal to
-LTE         : '<='; // less than or equal to
-GT          : G T;  // greater than
-LT          : L T;  // less than
-BTW         : '><'; // between two elements
-MATCH       : '~~';  // match
-NEGMATCH    : '!~';  // dont match
+EQ          : '='   ; // equal to
+NEQ         : '!=' ; // not equal to
+GTE         : '>=' ;  // greater than or equal to
+LTE         : '<=' ; // less than or equal to
+GT          : '>'   ;  // greater than
+LT          : '<'   ;  // less than
+BTW         : '><' ; // between two elements
+MATCH       : '~~'  ;  // match
+NEGMATCH    : '!~'  ;  // dont match
 
 // Logical operators - combine boolean expressions
-AND : A N D;
-OR  : O R;
+AND : '&&';
+OR  : '||';
 
 // Unary operators
 IN  : I N; // match an element in a defined range

--- a/src/test/java/com/gmathur/resql/integration/PgTest.java
+++ b/src/test/java/com/gmathur/resql/integration/PgTest.java
@@ -82,28 +82,28 @@ public class PgTest {
     }
     @Test
     public void gtGtLtSameFieldTest() throws SQLException {
-        final String clause = "length gt 52 and length lt 57";
+        final String clause = "length > 52 && length < 57";
         final Set<Integer> expected = new HashSet<>(Arrays.asList(8, 66, 97, 110, 164, 199));
         assertEquals(expected, runTestWithFilmIdResults(clause));
     }
 
     @Test
     public void gtGtLtDifferentFieldsTest() throws SQLException {
-        final String clause = "length gt 170   and  rental_duration lt  6";
+        final String clause = "length > 170   &&  rental_duration <  6";
         final Set<Integer> expected = new HashSet<>(Arrays.asList(50, 61, 126, 129, 177, 179, 180, 190));
         assertEquals(expected, runTestWithFilmIdResults(clause));
     }
 
     @Test
     public void parenOrAndAndTest() throws SQLException {
-        final String clause = "(rating EQ 'G' or rating eq 'PG') AND (length gt 180)";
+        final String clause = "(rating = 'G' || rating = 'PG') && (length > 180)";
         final Set<Integer> expected = new HashSet<>(Arrays.asList(50, 128, 182));
         assertEquals(expected, runTestWithFilmIdResults(clause));
     }
 
     @Test
     public void strInTestWithAndClauses() throws SQLException {
-        final String clause = "rating IN['G', 'PG'] anD film_id gt 10 And film_id lt 20";
+        final String clause = "rating IN['G', 'PG'] && film_id > 10 && film_id < 20";
         Set<Integer> expected = new HashSet<>(Arrays.asList(11, 12, 13, 19));
         assertEquals(expected, runTestWithFilmIdResults(clause));
     }
@@ -118,12 +118,12 @@ public class PgTest {
     @Test
     public void likeTest() throws SQLException {
         {
-            final String clause = "description ~~ '%rest%' AND description ~~ '%rama%'";
+            final String clause = "description ~~ '%rest%' && description ~~ '%rama%'";
             final Set<Integer> expected = new HashSet<>(Arrays.asList(6, 65, 100));
             assertEquals(expected, runTestWithFilmIdResults(clause));
         }
         {
-            final String clause = "description ~~ '%rest%' AND rental_duration EQ 3";
+            final String clause = "description ~~ '%rest%' && rental_duration = 3";
             final Set<Integer> expected = new HashSet<>(Arrays.asList(6, 65, 156));
             assertEquals(expected, runTestWithFilmIdResults(clause));
         }

--- a/src/test/java/com/gmathur/resql/unit/ResqlPgAdapterTest.java
+++ b/src/test/java/com/gmathur/resql/unit/ResqlPgAdapterTest.java
@@ -16,18 +16,18 @@ public class ResqlPgAdapterTest {
 
     @Test
     public void tc1GreaterThanOnlyAndIgnoringWhitespace() {
-        final String restWhereArg = "f1    gt    10";
+        final String restWhereArg = "f1    >    10";
         final Optional<String> res = w.process(restWhereArg);
         assertTrue(res.isPresent()); assertEquals("f1 > 10", res.get());
     }
 
     @Test
     public void tc2LessThanOnlyAndNoWhitespace() {
-        final String restWhereArg1 = "f1 lt 17";
+        final String restWhereArg1 = "f1 < 17";
         final Optional<String> res = w.process(restWhereArg1);
         assertTrue(res.isPresent()); assertEquals("f1 < 17", res.get());
 
-        final String restWhereArg2 = "f1   lt   17";
+        final String restWhereArg2 = "f1  <   17";
         final Optional<String> res2 = w.process(restWhereArg2);
         assertTrue(res2.isPresent()); assertEquals("f1 < 17", res2.get());
     }
@@ -39,7 +39,7 @@ public class ResqlPgAdapterTest {
         final Optional<String> res1 = w.process(restWhereArg1);
         assertTrue(res1.isPresent()); assertEquals(expected1, res1.get());
 
-        final String restWhereArg2 = "age  ><   (20,   31)";
+        final String restWhereArg2 = "age  ><  (20,   31)";
         final String expected2 = "(age >= 20 AND age < 31)";
         final Optional<String> res2 = w.process(restWhereArg2);
         assertTrue(res2.isPresent()); assertEquals(expected2, res2.get());
@@ -55,22 +55,22 @@ public class ResqlPgAdapterTest {
 
     @Test
     public void tc5gtAndLtCombinations() {
-        final String restWhereArg1 = "age GT 10  AND size  LT   100";
+        final String restWhereArg1 = "age > 10  && size  <   100";
         final String expected1 = "age > 10 AND size < 100";
         final Optional<String> res1 = w.process(restWhereArg1);
         assertTrue(res1.isPresent()); assertEquals(expected1, res1.get());
 
-        final String restWhereArg2 = "age lT 50    AND size  gT 100";
+        final String restWhereArg2 = "age < 50    && size  > 100";
         final String expected2 = "age < 50 AND size > 100";
         final Optional<String> res2 = w.process(restWhereArg2);
         assertTrue(res2.isPresent()); assertEquals(expected2, res2.get());
 
-        final String restWhereArg3 = "age Gt 50 AND size Gt 10";
+        final String restWhereArg3 = "age > 50 && size > 10";
         final String expected3 = "age > 50 AND size > 10";
         final Optional<String> res3 = w.process(restWhereArg3);
         assertTrue(res3.isPresent()); assertEquals(expected3, res3.get());
 
-        final String restWhereArg4 = "age LT 50 AND size LT 10";
+        final String restWhereArg4 = "age < 50 && size < 10";
         final String expected4 = "age < 50 AND size < 10";
         final Optional<String> res4 = w.process(restWhereArg4);
         assertTrue(res4.isPresent()); assertEquals(expected4, res4.get());
@@ -78,20 +78,20 @@ public class ResqlPgAdapterTest {
 
     @Test
     public void tc6FloatingPoint() {
-        final String restWhereArg1 = "width_ft GT 10.22 AND length  <= 100.2  AND height_ft <= 0.22";
+        final String restWhereArg1 = "width_ft > 10.22 && length  <= 100.2  && height_ft <= 0.22";
         final String expected1 = "width_ft > 10.22 AND length >= 100.2 AND height_ft >= 0.22";
         final Optional<String> res1 = w.process(restWhereArg1);
         assertTrue(res1.isPresent()); assertEquals(expected1, res1.get());
 
-        final String restWhereArg2 = "(width_ft GT 10.22 OR length  <= 100.2) and height_ft <= 0.22";
+        final String restWhereArg2 = "(width_ft > 10.22 || length  <= 100.2) && height_ft <= 0.22";
         final String expected2 = "(width_ft > 10.22 OR length >= 100.2) AND height_ft >= 0.22";
         final Optional<String> res2 = w.process(restWhereArg2);
         assertTrue(res2.isPresent()); assertEquals(expected2, res2.get());
     }
-  
+
     @Test
     public void tc7LogicalAnd() {
-        final String restWhereArg1 = "age LT 50 and size LT 10 or city EQ 'fremont'";
+        final String restWhereArg1 = "age < 50 && size < 10 || city = 'fremont'";
         final String expected1 = "age < 50 AND size < 10 OR city = 'fremont'";
         final Optional<String> res1 = w.process(restWhereArg1);
         assertTrue(res1.isPresent()); assertEquals(expected1, res1.get());
@@ -100,7 +100,7 @@ public class ResqlPgAdapterTest {
 
     @Test
     public void tc8ComplexWhere() {
-        final String restWhereArg = "(f1 EQ 10 AND (f2 != 11 OR f3 EQ 12) And (f4 GT 13)) oR (f5 EQ 'hello') Or (f6 in[321, 11, 17]) or f7 ><(1, 100)";
+        final String restWhereArg = "(f1 = 10 && (f2 != 11 || f3 = 12) && (f4 > 13)) || (f5 = 'hello') || (f6 IN[321, 11, 17]) || f7 ><(1, 100)";
         final String expected = "(f1 = 10 AND (f2 != 11 OR f3 = 12) AND (f4 > 13)) OR (f5 = 'hello') OR (f6 IN (321,11,17)) OR (f7 >= 1 AND f7 < 100)";
 
         final Optional<String> res = w.process(restWhereArg);
@@ -111,12 +111,12 @@ public class ResqlPgAdapterTest {
 
     @Test
     public void tc9FieldsCanHaveUnderscore() {
-        final String restWhereArg1 = "rental_length GT 10";
+        final String restWhereArg1 = "rental_length > 10";
         final String expected1 = "rental_length > 10";
         final Optional<String> res1 = w.process(restWhereArg1);
         assertTrue(res1.isPresent()); assertEquals(expected1, res1.get());
     }
-  
+
     private void assertThrowsCheck(final String clause) {
         assertThrows(ResqlParseException.class, () -> {
             final String restWhereArg1 = clause;
@@ -127,17 +127,17 @@ public class ResqlPgAdapterTest {
     public void tc10Invalid() {
         assertThrowsCheck("rental_length > 10 ?");
         assertThrowsCheck("rental_length");
-        assertThrowsCheck("rental_length = 10");
+        assertThrowsCheck("rental_length == 10");
         assertThrowsCheck("rental_length === 10");
         assertThrowsCheck("age << 10"); // unknown operator
         assertThrowsCheck("age >> 10"); // unknown operator
         assertThrowsCheck("a?ge > 10"); // non-identifier character
         assertThrowsCheck("?age > 10"); // extraneous leading ?
-        assertThrowsCheck("age ^^(10, 11)"); // in clause expects in set in brackets
-        assertThrowsCheck("age ^^[10, 11, 12"); // missing terminating bracket
-        assertThrowsCheck("age ><[10, 11]"); // brackets instead of paren
-        assertThrowsCheck("age ><((10, 11)"); // extraneous paren
-        assertThrowsCheck("age ><10, 11"); // missing paren
-        assertThrowsCheck("age ><10, 11");
+        assertThrowsCheck("age IN(10, 11)"); // in clause expects in set in brackets
+        assertThrowsCheck("age IN[10, 11, 12"); // missing terminating bracket
+        assertThrowsCheck("age BTW[10, 11]"); // brackets instead of paren
+        assertThrowsCheck("age BTW((10, 11)"); // extraneous paren
+        assertThrowsCheck("age BTW0, 11"); // missing paren
+        assertThrowsCheck("age BTW10, 11");
     }
 }


### PR DESCRIPTION
Initially I thought that I would introduce textual operators (gt, lt,
etc.), as most of the common logical and conditional operator symbols
are reserved characters according to RFC 3986. That would have meant
that an end user, entering the query as a REST GET query parameter
argument would have to percent encode these reserved characters. I
initially wanted to avoid having the user do that but I am coming around
to the idea that that's ok. The core audience for resql is likely not an
end-user, but other software applications. However, even for end-users
it's not that hard to encode a URI component at the click of a button,
like in the Postman interface.